### PR TITLE
Adding ability to seed hash with specified seeds

### DIFF
--- a/mmh3.go
+++ b/mmh3.go
@@ -13,13 +13,14 @@ const (
 	h64c2 uint64 = 0x4cf5ad432745937f
 )
 
-func Hash32(key []byte) uint32 {
+func Hash32(key []byte, seed uint32) uint32 {
 	length := len(key)
 	if length == 0 {
 		return 0
 	}
 	nblocks := length / 4
 	var h, k uint32
+	h = seed
 	for i := 0; i < nblocks; i++ {
 		k = binary.LittleEndian.Uint32(key[i*4:])
 		k *= h32c1
@@ -54,7 +55,7 @@ func Hash32(key []byte) uint32 {
 	return h
 }
 
-func Hash128(key []byte) []byte {
+func Hash128(key []byte, seed uint64) []byte {
 	length := len(key)
 	ret := make([]byte, 16)
 	if length == 0 {
@@ -62,6 +63,8 @@ func Hash128(key []byte) []byte {
 	}
 	nblocks := length / 16
 	var h1, h2, k1, k2 uint64
+	h1 = seed
+	h2 = seed
 	for i := 0; i < nblocks; i++ {
 		k1 = binary.LittleEndian.Uint64(key[i*16:])
 		k2 = binary.LittleEndian.Uint64(key[(i*16)+8:])
@@ -160,7 +163,7 @@ func Hash128(key []byte) []byte {
 // Hash128x64 is a version of MurmurHash which is designed to run only on
 // little-endian processors.  It is considerably faster for those processors
 // than Hash128.
-func Hash128x64(key []byte) []byte {
+func Hash128x64(key []byte, seed uint64) []byte {
 	length := len(key)
 	ret := make([]byte, 16)
 	if length == 0 {
@@ -177,6 +180,8 @@ func Hash128x64(key []byte) []byte {
 	b := *(*[]uint64)(unsafe.Pointer(&h))
 	for i := 0; i < len(b); i += 2 {
 		k1, k2 = b[i], b[i+1]
+		h1 ^= seed
+		h2 ^= seed
 		k1 *= h64c1
 		k1 = (k1 << 31) | (k1 >> (64 - 31))
 		k1 *= h64c2

--- a/mmh3.go
+++ b/mmh3.go
@@ -174,14 +174,13 @@ func Hash128x64(key []byte, seed uint64) []byte {
 
 	nblocks := length / 16
 	var h1, h2, k1, k2 uint64
-
+	h1 = seed
+	h2 = seed
 	h := *(*reflect.SliceHeader)(unsafe.Pointer(&key))
 	h.Len = nblocks * 2
 	b := *(*[]uint64)(unsafe.Pointer(&h))
 	for i := 0; i < len(b); i += 2 {
 		k1, k2 = b[i], b[i+1]
-		h1 ^= seed
-		h2 ^= seed
 		k1 *= h64c1
 		k1 = (k1 << 31) | (k1 >> (64 - 31))
 		k1 *= h64c2

--- a/mmh3_test.go
+++ b/mmh3_test.go
@@ -5,19 +5,54 @@ import (
 	"testing"
 )
 
-func TestAll(t *testing.T) {
+
+// original tests should still succeed with seeds uninitialized or set to 0 - adding new tests to func TestSeed
+
+func TestSeed(t *testing.T) {
+
+	var seed_32_1, seed_32_2 uint32
+	var seed_64_1, seed_64_2 uint64
+
+	seed_32_1 = 2
+	seed_32_2 = 128
+
+	seed_64_1 = 2
+	seed_64_2 = 128
+
 	s := []byte("hello")
-	if Hash32(s) != 0x248bfa47 {
+	if Hash32(s, seed_32_1) == Hash32(s, seed_32_2) {
 		t.Fatal("32bit hello")
 	}
-	if fmt.Sprintf("%x", Hash128(s)) != "029bbd41b3a7d8cb191dae486a901e5b" {
+	if fmt.Sprintf("%x", Hash128(s, seed_64_1)) == fmt.Sprintf("%x", Hash128(s, seed_64_2)) {
+		t.Fatal("128bit hello ", Hash128(s, seed_64_1), Hash128(s, seed_64_2))
+	}
+	s = []byte("Winter is coming")
+	if Hash32(s, seed_32_1) == Hash32(s, seed_32_2) {
+		t.Fatal("32bit winter")
+	}
+	if fmt.Sprintf("%x", Hash128(s, seed_64_1)) == fmt.Sprintf("%x", Hash128(s, seed_64_2)) {
+		t.Fatal("128bit winter", Hash128(s, seed_64_1), Hash128(s, seed_64_2))
+	}
+
+}
+
+func TestAll(t *testing.T) {
+
+	var seed_32 uint32
+	var seed_64 uint64
+
+	s := []byte("hello")
+	if Hash32(s, seed_32) != 0x248bfa47 {
+		t.Fatal("32bit hello")
+	}
+	if fmt.Sprintf("%x", Hash128(s, seed_64)) != "029bbd41b3a7d8cb191dae486a901e5b" {
 		t.Fatal("128bit hello")
 	}
 	s = []byte("Winter is coming")
-	if Hash32(s) != 0x43617e8f {
+	if Hash32(s, seed_32) != 0x43617e8f {
 		t.Fatal("32bit winter")
 	}
-	if fmt.Sprintf("%x", Hash128(s)) != "95eddc615d3b376c13fb0b0cead849c5" {
+	if fmt.Sprintf("%x", Hash128(s, seed_64)) != "95eddc615d3b376c13fb0b0cead849c5" {
 		t.Fatal("128bit winter")
 	}
 }
@@ -29,9 +64,12 @@ func Testx64(t *testing.T) {
 		"Winter is coming",
 	}
 
+	var seed_64 uint64
+	seed_64 = 0
+
 	for _, k := range keys {
-		h128 := Hash128([]byte(k))
-		h128x64 := Hash128x64([]byte(k))
+		h128 := Hash128([]byte(k),seed_64)
+		h128x64 := Hash128x64([]byte(k), seed_64)
 
 		if string(h128) != string(h128x64) {
 			t.Fatalf("Expected same hashes for %s, but got %x and %x", k, h128, h128x64)


### PR DESCRIPTION
The ability to seed hashes comes in handy for situations where the same input should generate a different output, but should do so consistently, i.e. the same input given to the hash with the same seed should give the same output, but changing the seed will give a different output