### PR TITLE
Add a WriteHash128x64 method 

### DIFF
--- a/mmh3.go
+++ b/mmh3.go
@@ -168,14 +168,14 @@ func Hash128x64(key []byte) []byte {
 
 // WriteHash128x64 is a version of MurmurHash which is designed to run only on
 // little-endian processors.  It is considerably faster for those processors
-// than Hash128.  The hash is written to the first 16 bytes of ret
+// than Hash128.  The hash is written to the output buffer which should be 16 bytes long
 func WriteHash128x64(key, ret []byte) {
 	length := len(key)
 	if length == 0 {
 		return
 	}
-	if len(ret) < 16 {
-		panic("provided return buffer is less than 16 bytes")
+	if len(ret) != 16 {
+		panic("provided return buffer should be 16 bytes")
 	}
 
 	rh := *(*reflect.SliceHeader)(unsafe.Pointer(&ret))

--- a/mmh3.go
+++ b/mmh3.go
@@ -157,14 +157,22 @@ func Hash128(key []byte) []byte {
 	return ret
 }
 
-// Hash128x64 is a version of MurmurHash which is designed to run only on
-// little-endian processors.  It is considerably faster for those processors
-// than Hash128.
+// Hash128x64 calls WriteHash128x64 with an allocated output buffer
 func Hash128x64(key []byte) []byte {
-	length := len(key)
 	ret := make([]byte, 16)
+	if len(key) > 0 {
+		WriteHash128x64(key, ret)
+	}
+	return ret
+}
+
+// WriteHash128x64 is a version of MurmurHash which is designed to run only on
+// little-endian processors.  It is considerably faster for those processors
+// than Hash128.  The hash is written to the first two bytes of ret
+func WriteHash128x64(key, ret []byte) {
+	length := len(key)
 	if length == 0 {
-		return ret
+		return
 	}
 
 	rh := *(*reflect.SliceHeader)(unsafe.Pointer(&ret))
@@ -272,7 +280,6 @@ func Hash128x64(key []byte) []byte {
 	b[0] = h1
 	b[1] = h2
 	rh.Len = 16
-	return ret
 }
 
 type HashWriter128 struct {

--- a/mmh3.go
+++ b/mmh3.go
@@ -168,11 +168,14 @@ func Hash128x64(key []byte) []byte {
 
 // WriteHash128x64 is a version of MurmurHash which is designed to run only on
 // little-endian processors.  It is considerably faster for those processors
-// than Hash128.  The hash is written to the first two bytes of ret
+// than Hash128.  The hash is written to the first 16 bytes of ret
 func WriteHash128x64(key, ret []byte) {
 	length := len(key)
 	if length == 0 {
 		return
+	}
+	if len(ret) < 16 {
+		panic("provided return buffer is less than 16 bytes")
 	}
 
 	rh := *(*reflect.SliceHeader)(unsafe.Pointer(&ret))

--- a/mmh3_test.go
+++ b/mmh3_test.go
@@ -23,7 +23,7 @@ func TestAll(t *testing.T) {
 }
 
 // Test the x64 optimized hash against Hash128
-func Testx64(t *testing.T) {
+func TestOptimizedX64(t *testing.T) {
 	keys := []string{
 		"hello",
 		"Winter is coming",


### PR DESCRIPTION
This allows writing to an existing slice instead of allocating a new one each time